### PR TITLE
Don't return the same cinema in a 'many' request

### DIFF
--- a/routes/get.js
+++ b/routes/get.js
@@ -37,9 +37,9 @@ router.get('/times/cinema/:venueID', function(req, res){
 
 router.get('/times/many/:venueIDs', function(req, res){
 
-	const venueIDs = req.params.venueIDs.split(',');
+	const venueIDs = Array.from( new Set( req.params.venueIDs.split(',') ) );
 	const dayOffset = req.query.day;
-
+	
 	const times = venueIDs.map(venueID => {
 
 		return FaF.getListings(venueID, dayOffset)


### PR DESCRIPTION
The potential for causing an out-of-memory error existed in the `/get/times/many` endpoint.

There was no limit to the number of times that the same cinema ID could be passed in the URL for results to be passed.

Although this data would have been retrieved from the in-memory cache after the first load, the response body could have a huge size with the same information being returned potentially limitless times.

The resulting string could feasibly have grown to such a size that the server would run out of memory and crash.

This has been rectified by adding a list of cinema IDs into a `Set` (which only allows for one instance of each unique thing), and then an array being created from that set (the avoid the need for rewriting the logic to return the results).

Perhaps not the most efficient solution, but I believe it's the most optimal to achieve the result and retain code readability.