### PR TITLE
Add max size to FaF cache - make sure to parse as a number.

### DIFF
--- a/bin/lib/day-offset-to-datestamp.js
+++ b/bin/lib/day-offset-to-datestamp.js
@@ -5,5 +5,5 @@ const DAY_IN_SECONDS = 86400;
 
 module.exports = function(offset){
 	debug(`Offset is ${offset}`);
-	return moment( ( new Date() / 1000 ) + offset * DAY_IN_SECONDS , "X").format("YYYY-MM-DD");
+	return moment( ( new Date() / 1000 ) + (offset * DAY_IN_SECONDS) , "X").format("YYYY-MM-DD");
 };

--- a/bin/lib/fafScraper.js
+++ b/bin/lib/fafScraper.js
@@ -11,7 +11,8 @@ const offsetToDatestamp = require('./day-offset-to-datestamp');
 const shelfLife = require('./shelf-life');
 
 const cache = LRU({
-	length: function (n, key) { return n * 2 + key.length }
+	length: function (n, key) { return n * 2 + key.length },
+	max : Number(process.env.LRU_MAX) || 0
 });
 
 const fafAPI = "http://www.findanyfilm.com"

--- a/bin/lib/locationInterface.js
+++ b/bin/lib/locationInterface.js
@@ -9,7 +9,7 @@ const postCodeAPI = 'http://api.postcodes.io/postcodes';
 const nominatimAPI = 'http://nominatim.openstreetmap.org';
 const cache = LRU({
 	length: function (n, key) { return n * 2 + key.length },
-	max : process.env.LRU_MAX || 0
+	max : Number(process.env.LRU_MAX) || 0
 });
 
 function validatePostcode (postcode){
@@ -96,6 +96,8 @@ function searchForLocation (location){
 		return Promise.reject("A location was not passed to the function");
 	}
 	
+	location = location.toLowerCase();
+
 	const nominatimQuery = `${nominatimAPI}/search?q=${location}&countrycodes=gb&format=json&limit=10`;
 
 	const cachedVersion = cache.get(`nominatim-search:${location}`);

--- a/bin/lib/preload.js
+++ b/bin/lib/preload.js
@@ -12,7 +12,7 @@ module.exports = function(){
 		places.forEach( (place, idx) => {
 
 			setTimeout(function(){
-				debug(`Caching results for ${place}`);
+				debug(`Getting results to cache for ${place}`);
 				fetch(`http://localhost:${process.env.PORT}/search/cinemas/location/${place}`)
 					.then(res => res.json())
 					.then(data => {


### PR DESCRIPTION
Make location searches lower case to reduce the number of possible duplicates in cache.